### PR TITLE
refactor: 統一 trial 狀態流轉介面，支援 transition_status 並簡化狀態切換流程

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from torch import nn, optim
 from torch.utils.data import DataLoader
 from torchvision import models, transforms
 
-from src.config import DATASET_PATH, MAX_GENERATION
+from src.config import DATASET_PATH
 from src.trial_state import TrialState
 from src.tuner import Tuner
 from src.utils import Checkpoint, Hyperparameter, get_head_node_address, unzip_file
@@ -63,17 +63,6 @@ def cifar10_data_loader_factory(
         transform=test_transform,
     )
 
-    # np.random.seed(42)
-    # indices = np.random.permutation(len(test_dataset))
-    # test_size = len(test_dataset) // 2
-    # test_indices = indices[:test_size]
-    # valid_indices = indices[test_size:]
-    #
-    # valid_dataset = Subset(test_dataset, valid_indices.tolist())
-    # test_dataset = Subset(test_dataset, test_indices.tolist())
-
-    # print(f"{len(train_dataset)=}, {len(valid_dataset)=}, {len(test_dataset)=}")
-
     train_loader = DataLoader(
         train_dataset,
         batch_size=batch_size,
@@ -87,19 +76,6 @@ def cifar10_data_loader_factory(
         num_workers=num_workers,
     )
 
-    # valid_loader = DataLoader(
-    #     valid_dataset,
-    #     batch_size=batch_size,
-    #     shuffle=True,
-    # )
-    #
-    # test_loader = DataLoader(
-    #     test_dataset,
-    #     batch_size=batch_size,
-    #     shuffle=False,
-    # )
-
-    # return train_loader, valid_loader, test_loader
     return train_loader, valid_loader, None
 
 

--- a/src/trial_scheduler.py
+++ b/src/trial_scheduler.py
@@ -9,7 +9,7 @@ from ray.actor import ActorHandle
 
 from src.config import CPU_TRIALS_LIMIT, GPU_TRIALS_LIMIT
 
-from .utils import WorkerType
+from .utils import TrialStatus, WorkerType
 from .worker_manager import WorkerManager
 
 
@@ -82,7 +82,7 @@ def stealing_strategy(
     logger.info("嘗試從 CPU Worker %d 偷取 Trial %d", worker.id, trial_id)
     worker.ref.stealing_trial.remote(trial_id)  # type: ignore[reportGeneralTypeIssues])
     worker_manager.release_slots(worker.id, trial_id)
-    ray.get(trial_manager.transition_to_pending.remote(trial_id))  # type: ignore[reportGeneralTypeIssues]
+    ray.get(trial_manager.transition_status.remote(trial_id, TrialStatus.PENDING))  # type: ignore[reportGeneralTypeIssues]
 
 
 def get_trial_scheduler_logger() -> logging.Logger:

--- a/src/worker.py
+++ b/src/worker.py
@@ -16,6 +16,7 @@ from .utils import (
     Checkpoint,
     DataloaderFactory,
     TrainStepFunction,
+    TrialStatus,
     WorkerState,
     WorkerType,
     timer,
@@ -250,8 +251,9 @@ class Worker:
                 continue
 
             ray.get(
-                self.trial_manager.transition_to_running.remote(  # type: ignore[reportGeneralTypeIssues]
+                self.trial_manager.transition_status.remote(  # type: ignore[reportGeneralTypeIssues]
                     trial_state.id,
+                    TrialStatus.RUNNING,
                     {
                         "worker_id": self.worker_state.id,
                         "worker_type": self.worker_state.worker_type,


### PR DESCRIPTION
- main.py: 移除多餘註解，簡化資料集分割程式碼。
- trial_manager.py:
  - ALLOWED_TRANSITION 新增 WAITING 可回到 PENDING，強化試驗調度彈性。
  - 將 transition_to_waiting/running/pending/completed 等方法標記為私有（_），集中對外暴露 transition_status 統一入口。
  - transition_status 支援根據 enum 進行分派，減少重複邏輯，提高維護性。
  - acquire_pending_trials 與 acquire_pending_trial_for_xxx 皆改調用 _transition_to_waiting。
  - log 最佳紀錄時顯示完整浮點數精度。
- trial_scheduler.py:
  - 調用 stealing_strategy 時，改用 trial_manager.transition_status 統一狀態流轉。
- tuner.py:
  - 所有 on_trial_complete/on_trial_step_complete/on_trial_need_mutation 狀態更新，都統一改用 transition_status。
  - 移除 new_partial 變數，直接於 partial 中設置 worker_id/worker_type。
- worker.py:
  - worker 啟動時，將 trial 狀態轉為 RUNNING 也統一改用 transition_status。
  - 匯入 TrialStatus，便於直接 enum 呼叫。